### PR TITLE
Option to only use every 10th measurement

### DIFF
--- a/app/redux/slices/sheepRttPointsSlice.ts
+++ b/app/redux/slices/sheepRttPointsSlice.ts
@@ -68,9 +68,12 @@ function getEvery10thMeasurement(rttPointsInArrays : Map<number, Feature<Point>[
             counter++;
         })
     })
-    return newArray;
+    return newArray.sort(sortById);
 }
 
+function sortById(a: Feature<Point>, b: Feature<Point>) { 
+    return Number(a?.id) - Number(b?.id);
+}
 
 export const {storeSheepRttPoint, setSheepRttPoints, removeSheepRttPoints} = sheepRttPoints.actions;
 

--- a/app/redux/slices/sheepRttPointsSlice.ts
+++ b/app/redux/slices/sheepRttPointsSlice.ts
@@ -2,6 +2,8 @@ import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 import {RootState} from '../store';
 import {Feature, FeatureCollection, Point} from "geojson";
 
+const USE_ONLY_EVERY_10TH_MEASUREMENT = false;
+
 const sheepRttPoints = createSlice({
     name: 'sheepRttPoints',
     initialState: {value: <FeatureCollection<Point>> {type: "FeatureCollection", features: []}},
@@ -20,13 +22,62 @@ const sheepRttPoints = createSlice({
             }
         },
         setSheepRttPoints: (state, action: PayloadAction<FeatureCollection<Point>>) => {
-            state.value = action.payload;
+            if (USE_ONLY_EVERY_10TH_MEASUREMENT) {
+                const allRTTPoints = action.payload
+                const every10thRTTMeasurement = onlyEver10thMeasurement(allRTTPoints)
+            }
+            else {
+                console.log(onlyEver10thMeasurement(action.payload));
+                state.value = action.payload;
+            }
+            
         },
         removeSheepRttPoints: (state) => {
             state.value = {type: "FeatureCollection", features: []};
         },
     },
 });
+
+function onlyEver10thMeasurement(allRTTPoints : FeatureCollection<Point>) {
+    //const filteredPoints:  FeatureCollection<Point> = null;
+    const rttPointsSplitIntoArrays = splitIntoArrayForEachTagID(allRTTPoints);
+    console.log(rttPointsSplitIntoArrays)
+    return getEvery10thMeasurement(rttPointsSplitIntoArrays);
+}
+
+function splitIntoArrayForEachTagID(allRTTPoints : FeatureCollection<Point>): Map<number, Feature<Point>[]> {
+    const filteredPoints:  Feature<Point>[] = allRTTPoints.features;
+    const rttPointsSortedBySheepId = new Map<number, Feature<Point>[]>();
+    filteredPoints.forEach((point) => {
+        if (rttPointsSortedBySheepId.has(point?.properties?.tid)) {
+            rttPointsSortedBySheepId.get(point?.properties?.tid)!.push(point)
+        }
+        else {
+            rttPointsSortedBySheepId.set(point?.properties?.tid,[point])
+        }
+    })
+    return rttPointsSortedBySheepId;
+}
+
+function getEvery10thMeasurement(rttPointsInArrays : Map<number, Feature<Point>[]>) {
+    const newArray: Feature<Point>[] = [];
+    rttPointsInArrays.forEach((keyValue) => {
+        let counter = 0;
+        keyValue.forEach((feature, tagId) => {
+            if (counter === 0) {
+                newArray.push(feature);
+                counter++;
+            }
+            else if (counter === 9) {
+                counter = 0;
+            }
+            else {
+                counter++;
+            }
+        })
+    })
+    return newArray;
+}
 
 export const {storeSheepRttPoint, setSheepRttPoints, removeSheepRttPoints} = sheepRttPoints.actions;
 

--- a/app/redux/slices/sheepRttPointsSlice.ts
+++ b/app/redux/slices/sheepRttPointsSlice.ts
@@ -2,7 +2,7 @@ import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 import {RootState} from '../store';
 import {Feature, FeatureCollection, Point} from "geojson";
 
-const USE_ONLY_EVERY_10TH_MEASUREMENT = false;
+const USE_ONLY_EVERY_10TH_MEASUREMENT = true;
 
 const sheepRttPoints = createSlice({
     name: 'sheepRttPoints',
@@ -25,12 +25,12 @@ const sheepRttPoints = createSlice({
             if (USE_ONLY_EVERY_10TH_MEASUREMENT) {
                 const allRTTPoints = action.payload
                 const every10thRTTMeasurement = onlyEver10thMeasurement(allRTTPoints)
+                state.value = {type: "FeatureCollection", features: every10thRTTMeasurement};
             }
             else {
-                console.log(onlyEver10thMeasurement(action.payload));
+                
                 state.value = action.payload;
             }
-            
         },
         removeSheepRttPoints: (state) => {
             state.value = {type: "FeatureCollection", features: []};
@@ -39,9 +39,7 @@ const sheepRttPoints = createSlice({
 });
 
 function onlyEver10thMeasurement(allRTTPoints : FeatureCollection<Point>) {
-    //const filteredPoints:  FeatureCollection<Point> = null;
     const rttPointsSplitIntoArrays = splitIntoArrayForEachTagID(allRTTPoints);
-    console.log(rttPointsSplitIntoArrays)
     return getEvery10thMeasurement(rttPointsSplitIntoArrays);
 }
 
@@ -63,21 +61,16 @@ function getEvery10thMeasurement(rttPointsInArrays : Map<number, Feature<Point>[
     const newArray: Feature<Point>[] = [];
     rttPointsInArrays.forEach((keyValue) => {
         let counter = 0;
-        keyValue.forEach((feature, tagId) => {
-            if (counter === 0) {
+        keyValue.forEach((feature) => {
+            if (counter % 10 === 0) { //For every 10th measurement
                 newArray.push(feature);
-                counter++;
             }
-            else if (counter === 9) {
-                counter = 0;
-            }
-            else {
-                counter++;
-            }
+            counter++;
         })
     })
     return newArray;
 }
+
 
 export const {storeSheepRttPoint, setSheepRttPoints, removeSheepRttPoints} = sheepRttPoints.actions;
 


### PR DESCRIPTION
Added config value USE_ONLY_EVERY_10TH_MEASUREMENT = false; to sheepRttPointsSlice.ts. 
Flip it to true and recompile, and the software will read only every 10th measurement. The exception being when storeSheepRttPoint is used.